### PR TITLE
Feature/nex 290/remote delivery testing config

### DIFF
--- a/cypress.env.sample.json
+++ b/cypress.env.sample.json
@@ -1,7 +1,11 @@
 {
-  "baseUrl": "http://localhost:8000",
+  "baseUrl": "https://currentgen.docker.localhost",
+  "taoDeliverBackendUrl": "https://deliver.docker.localhost",
+  "taoDeliverFrontendUrl": "https://testrunner.docker.localhost",
   "integrationFolder": "../../../../../..",
   "testFiles": "tao/views/js/e2e/**/*.spec.js",
   "adminUser": "admin",
-  "adminPass": "admin"
+  "adminPass": "admin",
+  "bypassBackOffice": "false",
+  "deliverTenantLabel": "Customer 1 Deliver 2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-e2e-runner",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-e2e-runner",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "End to end test runner",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-290

I augmented the sample config with values for `taoDeliverBackendUrl`, `taoDeliverFrontendUrl`, `bypassBackOffice` and `deliverTenantLabel`. These are necessary for running the remote delivery tests created [here](https://github.com/oat-sa/extension-tao-testqti/pull/1590).

The values should be manually replaced by the user, based on the details of the environment on which he wishes to run the tests.